### PR TITLE
feat: implement attribute controls and modifiers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,22 +1,47 @@
-import { useState } from 'react';
-import './App.css';
-import { ATTRIBUTE_LIST, CLASS_LIST, SKILL_LIST } from './consts.js';
-
+import { useState } from "react";
+import "./App.css";
+import { ATTRIBUTE_LIST } from "./consts";
 
 function App() {
-  const [num, setNum] = useState<number>(0);
+  const [attributes, setAttributes] = useState({
+    Strength: 10,
+    Dexterity: 10,
+    Constitution: 10,
+    Intelligence: 10,
+    Wisdom: 10,
+    Charisma: 10,
+  });
+
+  const calculateModifier = (value: number) => {
+    return Math.floor((value - 10) / 2);
+  };
+
+  const updateAttribute = (attr: string, change: number) => {
+    setAttributes((prev) => ({
+      ...prev,
+      [attr]: Math.max(0, prev[attr as keyof typeof attributes] + change), // Prevent negative values
+    }));
+  };
+
   return (
     <div className="App">
       <header className="App-header">
-        <h1>React Coding Exercise</h1>
+        <h1>Character Sheet</h1>
       </header>
       <section className="App-section">
-        <div>
-          Value:
-          {num}
-          <button>+</button>
-          <button>-</button>
-        </div>
+        <h2>Attributes</h2>
+        {ATTRIBUTE_LIST.map((attr) => (
+          <div key={attr} style={{ margin: "10px" }}>
+            {attr}: {attributes[attr as keyof typeof attributes]}
+            <button onClick={() => updateAttribute(attr, 1)}>+</button>
+            <button onClick={() => updateAttribute(attr, -1)}>-</button>
+            <span>
+              {" "}
+              Modifier:{" "}
+              {calculateModifier(attributes[attr as keyof typeof attributes])}
+            </span>
+          </div>
+        ))}
       </section>
     </div>
   );


### PR DESCRIPTION
# Description
This PR implements Requirements 1 and 4 for the character sheet app:
- Requirement 1: Added state for the 6 attributes (Strength, Dexterity, Constitution, Intelligence, Wisdom, Charisma) with independent increment/decrement controls. Attributes start at 10 and cannot go below 0.
- Requirement 4: Added ability modifiers to each attribute row, calculated as +1 for every 2 points above 10 (e.g., 7 → -2, 12 → 1, 20 → 5) using Math.floor((value - 10) / 2).