### PR TITLE
feat: implement skills and attribute maximum (req 5+7)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import "./App.css";
 import { Attributes as AttributesComponent } from "./components/Attributes";
 import { Classes } from "./components/Classes";
+import { Skills } from "./components/Skills";
 import { Attributes } from "./types";
 
 function App() {
@@ -13,6 +14,12 @@ function App() {
     Wisdom: 10,
     Charisma: 10,
   });
+
+  const [skillPoints, setSkillPoints] = useState<Record<string, number>>({});
+
+  const calculateModifier = (value: number) => Math.floor((value - 10) / 2);
+  const intelligenceModifier = calculateModifier(attributes.Intelligence);
+  const totalPointsAvailable = 10 + 4 * intelligenceModifier;
 
   return (
     <div className="App">
@@ -26,6 +33,12 @@ function App() {
             setAttributes={setAttributes}
           />
           <Classes attributes={attributes} />
+          <Skills
+            attributes={attributes}
+            skillPoints={skillPoints}
+            setSkillPoints={setSkillPoints}
+            totalPointsAvailable={totalPointsAvailable}
+          />
         </div>
       </section>
     </div>

--- a/src/components/Attributes.tsx
+++ b/src/components/Attributes.tsx
@@ -12,9 +12,16 @@ export const Attributes = ({ attributes, setAttributes }: AttributesProps) => {
   };
 
   const updateAttribute = (attr: string, change: number) => {
+    const currentValue = attributes[attr as keyof AttributesType];
+    const newValue = currentValue + change;
+
+    if (newValue < 0 || newValue > 70) {
+      return;
+    }
+
     setAttributes({
       ...attributes,
-      [attr]: Math.max(0, attributes[attr as keyof AttributesType] + change),
+      [attr]: newValue,
     });
   };
 

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -1,0 +1,73 @@
+import { SKILL_LIST } from "../consts";
+import { Attributes } from "../types";
+
+type SkillsProps = {
+  attributes: Attributes;
+  skillPoints: Record<string, number>;
+  setSkillPoints: (points: Record<string, number>) => void;
+  totalPointsAvailable: number;
+};
+
+export const Skills = ({
+  attributes,
+  skillPoints,
+  setSkillPoints,
+  totalPointsAvailable,
+}: SkillsProps) => {
+  const calculateModifier = (value: number) => Math.floor((value - 10) / 2);
+
+  const getSkillModifier = (attribute: string) => {
+    return calculateModifier(attributes[attribute as keyof Attributes]);
+  };
+
+  const updateSkillPoints = (skillName: string, change: number) => {
+    const currentTotalSpent = Object.values(skillPoints).reduce(
+      (sum, points) => sum + points,
+      0
+    );
+    const newPoints = Math.max(0, (skillPoints[skillName] || 0) + change);
+    const newTotalSpent = currentTotalSpent + change;
+
+    if (change > 0 && newTotalSpent > totalPointsAvailable) {
+      return;
+    }
+
+    setSkillPoints({
+      ...skillPoints,
+      [skillName]: newPoints,
+    });
+  };
+
+  const totalPointsSpent = Object.values(skillPoints).reduce(
+    (sum, points) => sum + points,
+    0
+  );
+
+  return (
+    <div>
+      <h2 className="section-title">Skills</h2>
+      <div>
+        Total Points Available: {totalPointsAvailable - totalPointsSpent} /{" "}
+        {totalPointsAvailable}
+      </div>
+      {SKILL_LIST.map((skill) => {
+        const modifier = getSkillModifier(skill.attributeModifier);
+        const points = skillPoints[skill.name] || 0;
+        const total = points + modifier;
+
+        return (
+          <div key={skill.name} className="item">
+            <span>
+              {skill.name} - points: {points}
+            </span>
+            <button onClick={() => updateSkillPoints(skill.name, 1)}>+</button>
+            <button onClick={() => updateSkillPoints(skill.name, -1)}>-</button>
+            <span>
+              modifier ({skill.attributeModifier}): {modifier} total: {total}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+};


### PR DESCRIPTION
# Description:
This PR implements Requirements 5 and 7:
- Requirement 5: Added `Skills.tsx` component to manage skill points:
  - Total points = 10 + (4 * Intelligence Modifier), with a minimum of 0 per skill.
  - Total skill value = points spent + attribute modifier (e.g., Acrobatics with 3 points and Dexterity modifier 2 = 5).
  - Displayed as rows (e.g., "Acrobatics - points: 3 [+] [-] modifier (Dex): 2 total: 5").
  - Tracks remaining points and prevents overspending.
- Requirement 7: Updated `Attributes.tsx` to enforce a maximum of `70` for all attributes, preventing increases beyond this limit.
Added skillPoints state in `App.tsx` to manage skill allocation